### PR TITLE
[채연] ETFList.tsx (즐겨 찾기 기능 삭제), ETFBox.tsx(즐겨 찾기 기능 삭제), ETFDetail.tsx (즐겨 찾기 기능 추가), HomeLayout.tsx (홈 버튼)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import Invest from '@/pages/invest/InvestMainBefore';
 import ETFBuy from '@/pages/invest/ETFBuy';
 import ETFSell from '@/pages/invest/ETFSell';
 import InvestmentHome from '@/pages/invest/InvestmentHome';
+import HomeLayout from './layout/HomeLayout';
 
 function App() {
   return (
@@ -31,18 +32,21 @@ function App() {
           <Route path="/donategoal" element={<DonateGoal />} /> {/* 기부 목표 금액 설정 페이지 */}
           <Route path="/donatehome" element={<DonateHome />} /> {/* 기부 메인 페이지 */}
           <Route path="/investbefore" element={<InvestMainBefore />} /> {/* 투자 페이지 */}
+          <Route path="/etf-detail/:symbol" element={<ETFDetail />} /> {/* ETF 상세 페이지 */}
+          <Route path="/InvestMainBefore" element={<Invest />} /> {/* 투자 시작 페이지 */}
+          <Route path="/investCategory" element={<InvestCategory />} /> {/* 투자 카테고리 페이지 */}
         </Route>
 
         <Route element={<PlusLayout />}>
-          <Route path="/InvestMainBefore" element={<Invest />} /> {/* 투자 시작 페이지 */}
-          <Route path="/investCategory" element={<InvestCategory />} /> {/* 투자 카테고리 페이지 */}
+          <Route path="/InvestmentHome" element={<InvestmentHome />} /> {/* 내 페이지 */}
+        </Route>
+
+        <Route element={<HomeLayout />}>
           <Route path="/etf-list" element={<ETFList />} /> {/* 내가 선택한 ETF 목록 */}
           <Route path="/etf-category/:category" element={<ETFCategoryList />} />{' '}
           {/* 투자 카테고리별 ETF 리스트 페이지 */}
-          <Route path="/etf-detail/:symbol" element={<ETFDetail />} /> {/* ETF 상세 페이지 */}
           <Route path="/etf-buy/:symbol" element={<ETFBuy />} /> {/* ETF 구매 페이지 */}
           <Route path="/etf-sell/:symbol" element={<ETFSell />} /> {/* ETF 판매 페이지 */}
-          <Route path="/InvestmentHome" element={<InvestmentHome />} /> {/* 내 페이지 */}
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/components/ETFBox.tsx
+++ b/src/components/ETFBox.tsx
@@ -1,23 +1,13 @@
-import { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import ETFIcon from '@/assets/ETFBox/ETFIcon.png';
-import { FaHeart } from 'react-icons/fa';
 
 const Box = styled.div<{ $isRecommend: boolean }>`
   display: flex;
   align-items: center;
   gap: 0.6rem;
   margin-left: ${({ $isRecommend }) => ($isRecommend ? '1.5rem' : '0.5rem')};
-  margin-right: 0.3rem;
+  margin-right: 0.1rem;
   font-weight: bold;
-  /* padding: 1rem; */
-  display: flex;
-  align-items: center;
-  gap: 0.8rem;
-  margin-left: ${({ $isRecommend }) => ($isRecommend ? '3rem' : '0.7rem')};
-  margin-right: 1.1rem;
-  font-weight: bold;
-  /* padding: 1rme; */
   border-radius: 8px;
   position: relative;
 `;
@@ -44,12 +34,12 @@ const ETFContent = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  margin-right: 1.2rem;
+  margin-right: 0.1rem;
   gap: 0.1rem;
 `;
 
 const ETFPrice = styled.div`
-  font-size: 1.1rem;
+  font-size: 0.9rem;
   color: white;
 `;
 
@@ -73,17 +63,6 @@ const EtfPriceContent = styled.div`
   gap: 0.2rem;
 `;
 
-const FavoriteButton = styled.button`
-  position: absolute;
-  top: 50%;
-  right: -1rem;
-  transform: translateY(-50%);
-  background: transparent;
-  border: none;
-  font-size: 1.2rem;
-  cursor: pointer;
-`;
-
 interface Props {
   name: string;
   price: number;
@@ -92,8 +71,6 @@ interface Props {
   isRecommend: boolean;
   isImageVisible?: boolean;
   onClick?: () => void;
-  onFavoriteToggle: (name: string) => void; // ✅ 관심 ETF 토글 핸들러
-  isFavorite: boolean; // ✅ 관심 ETF 여부
 }
 
 function ETFBox({
@@ -104,25 +81,10 @@ function ETFBox({
   isRecommend,
   isImageVisible = true,
   onClick,
-  onFavoriteToggle,
-  isFavorite,
 }: Props) {
   return (
     <Box $isRecommend={isRecommend} onClick={onClick}>
       {isImageVisible && <ETFImg src={ETFIcon} alt="ETF Icon" />}
-
-      {/* ✅ 관심 ETF 버튼 */}
-      <FavoriteButton
-        onClick={(e) => {
-          e.stopPropagation();
-          if (typeof onFavoriteToggle === 'function') {
-            onFavoriteToggle(name);
-            console.log(`✅ 하트 클릭됨: ${name}, 상태: ${!isFavorite}`);
-          }
-        }}
-      >
-        <FaHeart color={isFavorite ? '#FF0000' : '#CCCCCC'} /> {/* ❤️ 빨강 / 🤍 회색 */}
-      </FavoriteButton>
 
       <ETFContentBox>
         <ETFTitle>{name}</ETFTitle>

--- a/src/components/ETFQuantityBox.tsx
+++ b/src/components/ETFQuantityBox.tsx
@@ -13,8 +13,8 @@ const Box = styled.div<{ $isRecommend: boolean }>`
 `;
 
 const ETFImg = styled.img`
-  width: 2.4rem;
-  height: 2.4rem;
+  width: 2rem;
+  height: 2rem;
 `;
 
 const ETFContentBox = styled.div`
@@ -38,7 +38,7 @@ const ETFContent = styled.div`
 `;
 
 const ETFPrice = styled.div`
-  font-size: 1.1rem;
+  font-size: 1rem;
   color: white;
 `;
 

--- a/src/layout/HomeLayout.tsx
+++ b/src/layout/HomeLayout.tsx
@@ -1,0 +1,50 @@
+import { Outlet, useNavigate } from 'react-router-dom';
+import { colors } from '@/styles/colors';
+import styled from 'styled-components';
+
+import { IoChevronBackSharp } from 'react-icons/io5';
+import { MdHomeFilled } from 'react-icons/md';
+
+const Top = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const Icon = styled.div`
+  width: 1.5rem;
+  margin-bottom: 1rem;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+
+  &:active {
+    opacity: 0.6;
+  }
+`;
+
+export default function HomeLayout() {
+  const navigate = useNavigate();
+
+  const HandleBackClick = () => {
+    navigate(-1);
+  };
+
+  const HandleHomeClick = () => {
+    navigate('/InvestmentHome'); // ✅ 홈 아이콘 클릭 시 이동
+  };
+
+  return (
+    <div>
+      <Top>
+        <Icon onClick={HandleBackClick}>
+          <IoChevronBackSharp color={colors.White} size="1.5rem" />
+        </Icon>
+        <Icon onClick={HandleHomeClick}>
+          {/* ✅ 홈 아이콘에 클릭 이벤트 추가 */}
+          <MdHomeFilled color={colors.White} size="1.5rem" />
+        </Icon>
+      </Top>
+      <Outlet />
+    </div>
+  );
+}

--- a/src/pages/invest/ETFDetail.tsx
+++ b/src/pages/invest/ETFDetail.tsx
@@ -4,6 +4,7 @@ import axios from 'axios';
 import styled from 'styled-components';
 import CandlestickChart from '@/components/CandlestickChart';
 import { useNavigate } from 'react-router-dom';
+import { FaHeart } from 'react-icons/fa'; // ✅ 하트 아이콘 추가
 
 const Container = styled.div`
   /* margin-left: 0.5rem; */
@@ -162,6 +163,16 @@ const LargeBtn2 = styled.button`
   border-radius: 1.3rem; /* ✅ 버튼 둥글게 */
   background-color: #0064ff;
 `;
+/* ✅ 하트(즐겨찾기) 버튼 스타일 추가 */
+const FavoriteButton = styled.button`
+  background: transparent;
+  border: none;
+  font-size: 1.4rem;
+  cursor: pointer;
+  position: absolute;
+  top: 1rem;
+  right: 1.2rem;
+`;
 
 function ETFDetail() {
   const navigate = useNavigate();
@@ -171,6 +182,9 @@ function ETFDetail() {
   const [buyVolume, setBuyVolume] = useState(7500);
   const [sellVolume, setSellVolume] = useState(3500);
   const [timeRange, setTimeRange] = useState<'1d' | '1w' | '1mo' | '1y'>('1d');
+
+  // ✅ 관심 ETF 상태 추가
+  const [isFavorite, setIsFavorite] = useState<boolean>(false);
 
   useEffect(() => {
     async function fetchData() {
@@ -187,6 +201,27 @@ function ETFDetail() {
     }
     fetchData();
   }, [symbol]);
+
+  // ✅ 관심 ETF 목록 불러오기
+  useEffect(() => {
+    const favoriteETFs = JSON.parse(localStorage.getItem('favoriteETFs') || '[]');
+    setIsFavorite(favoriteETFs.includes(symbol));
+  }, [symbol]);
+
+  // ✅ 관심 ETF 토글 함수
+  const toggleFavorite = () => {
+    const favoriteETFs = JSON.parse(localStorage.getItem('favoriteETFs') || '[]');
+
+    let updatedFavorites;
+    if (favoriteETFs.includes(symbol)) {
+      updatedFavorites = favoriteETFs.filter((item: string) => item !== symbol);
+    } else {
+      updatedFavorites = [...favoriteETFs, symbol];
+    }
+
+    localStorage.setItem('favoriteETFs', JSON.stringify(updatedFavorites));
+    setIsFavorite(!isFavorite);
+  };
 
   if (error)
     return (
@@ -224,6 +259,10 @@ function ETFDetail() {
     max !== min ? ((value - min) / (max - min)) * 100 : 50;
   return (
     <Container>
+      <FavoriteButton onClick={toggleFavorite}>
+        <FaHeart color={isFavorite ? '#FF0000' : '#CCCCCC'} /> {/* ❤️ 빨강 / 🤍 회색 */}
+      </FavoriteButton>
+
       <EtfTile>{symbol} ETF</EtfTile>
       <CurPrice>{currentPrice} USD</CurPrice>
       <ChangeBox>

--- a/src/pages/invest/ETFList.tsx
+++ b/src/pages/invest/ETFList.tsx
@@ -18,22 +18,19 @@ const Container = styled.div`
   color: white;
 `;
 
-const Section = styled.div``;
 const CategoryList = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: flex-start;
   gap: 10px;
   margin-top: 1rem;
 `;
 
-const CategoryHeader = styled.div<{ $active: boolean }>`
+const CategoryHeader = styled.div`
   font-size: 1rem;
   font-weight: bold;
   padding: 10px 0;
   display: flex;
   justify-content: space-between;
-  opacity: ${({ $active }) => ($active ? 1 : 1)}; /* 활성 상태 시 불투명도 조정 */
   cursor: pointer;
 `;
 
@@ -41,7 +38,7 @@ const ETFSection = styled.div`
   margin-top: 10px;
 `;
 
-const ETFTitle1 = styled.h2`
+const ETFTitle = styled.h2`
   font-size: 1.1rem;
   font-weight: bold;
   letter-spacing: 0.25rem;
@@ -93,30 +90,9 @@ function ETFList() {
   const [previousCloseData, setPreviousCloseData] = useState<{ [key: string]: number }>({});
   const [randomETFs, setRandomETFs] = useState<{ [key: string]: any[] }>({});
 
-  const [watchlist, setWatchlist] = useState<string[]>(() => {
-    return JSON.parse(localStorage.getItem('favoriteETFs') || '[]');
-  });
-
-  // ✅ 관심 ETF 추가/삭제 함수
-  const toggleFavorite = (etfName: string) => {
-    setWatchlist((prevWatchlist) => {
-      const updatedWatchlist = prevWatchlist.includes(etfName)
-        ? prevWatchlist.filter((name) => name !== etfName)
-        : [...prevWatchlist, etfName];
-
-      localStorage.setItem('favoriteETFs', JSON.stringify(updatedWatchlist));
-
-      console.log('✅ 관심 ETF 업데이트됨:', updatedWatchlist); // 🚀 콘솔 확인
-      return updatedWatchlist;
-    });
-  };
-
-  useEffect(() => {
-    localStorage.setItem('favoriteETFs', JSON.stringify(watchlist));
-  }, [watchlist]);
-
   useEffect(() => {
     if (Object.keys(randomETFs).length > 0) return;
+
     console.log('📢 etfData 확인:', etfData);
     console.log('📢 선택된 카테고리:', selectedCategories);
 
@@ -132,7 +108,7 @@ function ETFList() {
 
       const etfs = etfData[englishCategory] ?? [];
 
-      if (etfs && etfs.length > 0) {
+      if (etfs.length > 0) {
         selectedETFData[category] = [...etfs].sort(() => 0.5 - Math.random()).slice(0, 3);
       } else {
         selectedETFData[category] = [];
@@ -185,72 +161,64 @@ function ETFList() {
 
   return (
     <Container>
-      <Section>
-        <ETFTitle1>관심 ETF 카테고리</ETFTitle1>
-        <CategoryList>
-          {selectedCategories.map((category) => (
-            <EtfCategoryBox
-              key={category}
-              title={category}
-              imageSrc={categoryImages[category]} // ✅ 이미지 추가
-              active={true} // ✅ 선택된 카테고리는 항상 활성화된 상태
-              onClick={() => console.log(`${category} 클릭됨`)}
-            />
-          ))}
-        </CategoryList>
-      </Section>
+      <ETFTitle>관심 ETF 카테고리</ETFTitle>
+      <CategoryList>
+        {selectedCategories.map((category) => (
+          <EtfCategoryBox
+            key={category}
+            title={category}
+            imageSrc={categoryImages[category]}
+            active={true}
+            onClick={() => console.log(`${category} 클릭됨`)}
+          />
+        ))}
+      </CategoryList>
 
       <Divider />
 
-      <Section>
-        <ETFTitle1>추천 ETF</ETFTitle1>
-        {selectedCategories.map((category) => (
-          <ETFSection key={category}>
-            <CategoryHeader>
-              <EtfCategoryBox
-                title={category}
-                imageSrc={categoryImages[category]} // ✅ 이미지 추가
-                active={true} // ✅ 선택된 카테고리는 항상 활성화된 상태
-                onClick={() => setExpandedCategory(expandedCategory === category ? null : category)}
+      <ETFTitle>추천 ETF</ETFTitle>
+      {selectedCategories.map((category) => (
+        <ETFSection key={category}>
+          <CategoryHeader>
+            <EtfCategoryBox
+              title={category}
+              imageSrc={categoryImages[category]}
+              active={true}
+              onClick={() => setExpandedCategory(expandedCategory === category ? null : category)}
+            />
+            <MoreButton
+              onClick={() =>
+                navigate(`/etf-category/${categoryMapping[category]}`, { state: { category } })
+              }
+            >
+              {'+'}
+            </MoreButton>
+          </CategoryHeader>
+
+          {(expandedCategory === category
+            ? etfData[categoryMapping[category]]
+            : randomETFs[category]
+          )?.map((etf) => {
+            const currentPrice = prices[etf] ?? 0;
+            const previousClose = previousCloseData[etf] ?? 0;
+            const priceChange = currentPrice - previousClose;
+            const changePercent =
+              previousClose !== 0 ? ((priceChange / previousClose) * 100).toFixed(1) : '0.0';
+
+            return (
+              <ETFBox
+                key={etf}
+                name={etf}
+                price={currentPrice}
+                transPrice={priceChange}
+                changePercent={changePercent}
+                isRecommend={true}
+                onClick={() => navigate(`/etf-detail/${etf}`)}
               />
-              {/* ✅ 올바른 이미지 사용 */}
-
-              <MoreButton
-                onClick={() =>
-                  navigate(`/etf-category/${categoryMapping[category]}`, { state: { category } })
-                }
-              >
-                {'+'}
-              </MoreButton>
-            </CategoryHeader>
-
-            {(expandedCategory === category
-              ? etfData[categoryMapping[category]]
-              : randomETFs[category]
-            )?.map((etf) => {
-              const currentPrice = prices[etf] ?? 0;
-              const previousClose = previousCloseData[etf] ?? 0;
-              const priceChange = currentPrice - previousClose;
-              const changePercent =
-                previousClose !== 0 ? ((priceChange / previousClose) * 100).toFixed(1) : '0.0';
-
-              return (
-                <ETFBox
-                  key={etf}
-                  name={etf}
-                  price={currentPrice}
-                  transPrice={priceChange}
-                  changePercent={changePercent}
-                  isRecommend={true}
-                  onClick={() => navigate(`/etf-detail/${etf}`)} // ✅ 클릭 시 이동
-                  onFavoriteToggle={toggleFavorite} // ✅ 관심 ETF 토글
-                  isFavorite={watchlist.includes(etf)} // ✅ 현재 ETF가 관심 ETF인지 여부
-                />
-              );
-            })}
-          </ETFSection>
-        ))}
-      </Section>
+            );
+          })}
+        </ETFSection>
+      ))}
     </Container>
   );
 }


### PR DESCRIPTION
## 📢 기능 설명

ETFList.tsx (즐겨 찾기 기능 삭제)
ETFBox.tsx(즐겨 찾기 기능 삭제)

ETFDetail.tsx (즐겨 찾기 기능 추가)
ETF 상세 페이지에서 특정 종목을 즐겨찾기(하트)로 추가/삭제 가능.
localStorage를 활용하여 관심 있는 ETF를 저장하고 유지.
하트 아이콘 클릭 시 관심 목록에 추가되며, 다시 클릭하면 제거됨.
관심 있는 종목은 빨간 하트, 그렇지 않으면 회색 하트로 표시됨.

HomeLayout.tsx (홈 버튼)
모든 페이지에서 상단 홈 버튼을 클릭하면 /InvestmentHome으로 이동하도록 설정.
<MdHomeFilled> 아이콘을 클릭하면 투자 홈(InvestmentHome) 페이지로 이동.
<IoChevronBackSharp> 버튼을 추가하여 이전 페이지로 돌아가기 기능 유지.

<br>

## 🔗 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #89 

<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.

<br>

## ✅ 체크리스트

- [v] PR 제목 규칙 잘 지켰는가?
- [v] 추가/수정사항을 설명하였는가?
- [v] 이슈넘버를 적었는가?
- [v] Approve 하기 전 확인 사항 체크했는가?
